### PR TITLE
Related search word container bug fix

### DIFF
--- a/src/components/oneFocus/ui/Header.tsx
+++ b/src/components/oneFocus/ui/Header.tsx
@@ -27,8 +27,10 @@ const Header: React.FC = () => {
   }, []);
 
   useEffect(() => {
+    const currentRef = searchContainerRef.current;
+
     const handleClickOutside = (event: MouseEvent) => {
-      if (!searchContainerRef.current?.contains(event.target as Node)) {
+      if (currentRef && !currentRef.contains(event.target as Node)) {
         setIsSearchFocused(false);
       }
     };
@@ -45,7 +47,7 @@ const Header: React.FC = () => {
           <br />
           <span className="text-base text-gray-800">{currentDateTime.date}</span>
         </div>
-        <div ref={searchContainerRef} className="relative flex-1" onMouseDown={(e) => e.stopPropagation()}>
+        <div ref={searchContainerRef} className="relative flex-1">
           <SiGoogle className="absolute left-3 top-3 h-4 w-4 text-gray-500" />
           <Input
             type="search"
@@ -67,10 +69,8 @@ const Header: React.FC = () => {
                   className={`flex items-center px-4 py-3 hover:bg-gray-100 cursor-pointer
                     ${index === selectedIndex ? 'bg-gray-100' : ''}
                   `}
-                  onClick={(e) => {
-                    e.stopPropagation();
+                  onClick={() => {
                     executeSearch(suggestion);
-                    setIsSearchFocused(false);
                   }}
                 >
                   <div className="flex items-center gap-4 flex-1">


### PR DESCRIPTION
close #36 

## 📌 Work Contents
- Related search word container bug fix

## 📋 Detailed & Screenshot
### Major Changes:
1. Troubleshoot the closure by capturing `searchContainerRef.current` as a local variable inside useEffect
2. Remove `setIsSearchFocused` and `searchContainerRef` from dependency array in useEffect
3. Modifying conditional statement logic to be more secure

This modification will ensure that the search bar will function normally after the reload.

Ref : [Closer-Understanding](https://velog.io/@lgs03042/JavaScript-%ED%81%B4%EB%A1%9C%EC%A0%80-%EC%9D%B4%ED%95%B4%ED%95%98%EA%B8%B0)

## ⭕ Confirmation Factor
- After refreshing, the relevant search term search should work normally.

## ❓ Question
